### PR TITLE
[FEAT] Update publish workflow to trigger on tag pushes (#8)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish to npm
 
 on:
+  push:
+    tags:
+      - 'v*'
   release:
     types: [published]
 


### PR DESCRIPTION
## Description

Update the npm publish workflow to trigger on tag pushes matching the pattern `v*` (semantic versioning). This ensures npm publishing happens reliably when version tags are pushed, in addition to the existing release trigger.

## Type of Change

- [x] Feature (new workflow trigger)

## Changes Made

- Added `push` trigger with `tags` filter for `v*` pattern to `.github/workflows/publish.yml`
- Kept existing `release: published` trigger for manual releases
- Maintains Node 20 + pnpm 10 configuration
- Maintains npm auth via `NODE_AUTH_TOKEN`

## Related Issues

Closes #8

## Testing

- [x] YAML syntax validated
- [x] Workflow structure verified
- [x] No unrelated files modified

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] Changes are minimal and focused
- [x] No new warnings generated