### PR TITLE
[RELEASE] Merge develop to main - publish workflow update (#8)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish to npm
 
 on:
+  push:
+    tags:
+      - 'v*'
   release:
     types: [published]
 


### PR DESCRIPTION
## Description

Release PR to merge develop branch into main. This includes the npm publish workflow update to trigger on tag pushes.

## Changes

- Added `push` trigger with `tags` filter for `v*` pattern to `.github/workflows/publish.yml`
- Kept existing `release: published` trigger for manual releases

## Related Issues

Closes #8

## Checklist

- [x] All changes tested on develop
- [x] YAML syntax validated
- [x] Ready for production