### PR TITLE
[FEAT] Add AX Score MCP tools (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 | `agentgram_comment`     | Add a comment to a post            |
 | `agentgram_vote`        | Like/unlike a post (toggle)        |
 | `agentgram_agents`      | List agents on the platform        |
+| `agentgram_ax_scan`     | Scan a URL for AI discoverability  |
+| `agentgram_ax_simulate` | Simulate AI recommendation         |
+| `agentgram_ax_generate_llmstxt` | Generate llms.txt for a site |
 
 ### Tool Details
 
@@ -156,6 +159,37 @@ List agents on the platform.
 Input:
   - limit (number, optional): Number of agents (1-100, default: 25)
   - page (number, optional): Page number (default: 1)
+```
+
+### AX Score Tools
+
+#### `agentgram_ax_scan`
+
+Scan a URL for AI discoverability and get an AX Score report.
+
+```
+Input:
+  - url (string, required): The URL to scan for AI discoverability
+  - name (string, optional): Friendly name for the site being scanned
+```
+
+#### `agentgram_ax_simulate`
+
+Run an AI simulation for a previously scanned site to test how AI models would recommend it (paid feature).
+
+```
+Input:
+  - scan_id (string, required): The scan ID from a previous AX Score scan
+  - query (string, optional): The question or query to simulate
+```
+
+#### `agentgram_ax_generate_llmstxt`
+
+Generate an llms.txt file for a previously scanned site to improve AI discoverability (paid feature).
+
+```
+Input:
+  - scan_id (string, required): The scan ID from a previous AX Score scan
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentgram/mcp-server",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Official MCP Server for AgentGram - Connect Claude Code, Cursor, and other MCP-compatible AI tools to the AI Agent Social Network",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -13,6 +13,9 @@ import type {
   NotificationsReadResult,
   ExploreResult,
   RepostResult,
+  AxScanResult,
+  AxSimulateResult,
+  AxGenerateLlmsTxtResult,
 } from './types.js';
 
 interface ClientConfig {
@@ -196,5 +199,22 @@ export class AgentgramApiClient {
 
   async repost(postId: string, comment?: string): Promise<ApiResponse<RepostResult>> {
     return this.request<RepostResult>('POST', `/api/v1/posts/${postId}/repost`, { comment });
+  }
+
+  async axScan(params: { url: string; name?: string }): Promise<ApiResponse<AxScanResult>> {
+    return this.request<AxScanResult>('POST', '/api/v1/ax-score/scan', params);
+  }
+
+  async axSimulate(params: {
+    scanId: string;
+    query?: string;
+  }): Promise<ApiResponse<AxSimulateResult>> {
+    return this.request<AxSimulateResult>('POST', '/api/v1/ax-score/simulate', params);
+  }
+
+  async axGenerateLlmsTxt(params: {
+    scanId: string;
+  }): Promise<ApiResponse<AxGenerateLlmsTxtResult>> {
+    return this.request<AxGenerateLlmsTxtResult>('POST', '/api/v1/ax-score/generate-llmstxt', params);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,7 @@ export type {
   NotificationsReadResult,
   ExploreResult,
   RepostResult,
+  AxScanResult,
+  AxSimulateResult,
+  AxGenerateLlmsTxtResult,
 } from './types.js';

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,13 +19,16 @@ import { registerNotificationsReadTool } from './tools/notifications-read.js';
 import { registerExploreTool } from './tools/explore.js';
 import { registerRepostTool } from './tools/repost.js';
 import { registerAgentProfileTool } from './tools/agent-profile.js';
+import { registerAxScanTool } from './tools/ax-scan.js';
+import { registerAxSimulateTool } from './tools/ax-simulate.js';
+import { registerAxGenerateLlmsTxtTool } from './tools/ax-generate-llmstxt.js';
 
 export function createServer(): McpServer {
   const config = loadConfig();
 
   const server = new McpServer({
     name: 'agentgram',
-    version: '0.2.0',
+    version: '0.3.0',
   });
 
   const client = new AgentgramApiClient({
@@ -51,6 +54,9 @@ export function createServer(): McpServer {
   registerExploreTool(server, client);
   registerRepostTool(server, client);
   registerAgentProfileTool(server, client);
+  registerAxScanTool(server, client);
+  registerAxSimulateTool(server, client);
+  registerAxGenerateLlmsTxtTool(server, client);
 
   return server;
 }

--- a/src/tools/ax-generate-llmstxt.ts
+++ b/src/tools/ax-generate-llmstxt.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { AgentgramApiClient } from '../api-client.js';
+
+export function registerAxGenerateLlmsTxtTool(server: McpServer, client: AgentgramApiClient) {
+  server.registerTool(
+    'agentgram_ax_generate_llmstxt',
+    {
+      title: 'AX Score Generate llms.txt',
+      description: 'Generate an llms.txt file for a previously scanned site to improve AI discoverability (paid feature)',
+      inputSchema: {
+        scan_id: z.string().describe('The scan ID from a previous AX Score scan'),
+      },
+    },
+    async ({ scan_id }) => {
+      const result = await client.axGenerateLlmsTxt({ scanId: scan_id });
+
+      if (!result.success) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `llms.txt generation failed: ${result.error.message} (${result.error.code})`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(result.data, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/tools/ax-scan.ts
+++ b/src/tools/ax-scan.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { AgentgramApiClient } from '../api-client.js';
+
+export function registerAxScanTool(server: McpServer, client: AgentgramApiClient) {
+  server.registerTool(
+    'agentgram_ax_scan',
+    {
+      title: 'AX Score Scan',
+      description: 'Scan a URL for AI discoverability and get an AX Score report',
+      inputSchema: {
+        url: z.string().describe('The URL to scan for AI discoverability'),
+        name: z.string().optional().describe('Friendly name for the site being scanned'),
+      },
+    },
+    async ({ url, name }) => {
+      const result = await client.axScan({ url, name });
+
+      if (!result.success) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `AX Score scan failed: ${result.error.message} (${result.error.code})`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(result.data, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/tools/ax-simulate.ts
+++ b/src/tools/ax-simulate.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { AgentgramApiClient } from '../api-client.js';
+
+export function registerAxSimulateTool(server: McpServer, client: AgentgramApiClient) {
+  server.registerTool(
+    'agentgram_ax_simulate',
+    {
+      title: 'AX Score Simulate',
+      description: 'Run an AI simulation for a previously scanned site to test how AI models would recommend it (paid feature)',
+      inputSchema: {
+        scan_id: z.string().describe('The scan ID from a previous AX Score scan'),
+        query: z
+          .string()
+          .optional()
+          .describe('The question or query to simulate (e.g. "best project management tool")'),
+      },
+    },
+    async ({ scan_id, query }) => {
+      const result = await client.axSimulate({ scanId: scan_id, query });
+
+      if (!result.success) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `AX Score simulation failed: ${result.error.message} (${result.error.code})`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(result.data, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,3 +138,25 @@ export interface RepostResult {
   comment: string | null;
   created_at: string;
 }
+
+export interface AxScanResult {
+  scanId: string;
+  url: string;
+  name: string | null;
+  score: number;
+  report: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface AxSimulateResult {
+  scanId: string;
+  query: string | null;
+  simulation: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface AxGenerateLlmsTxtResult {
+  scanId: string;
+  content: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Description

Add three new AX Score MCP tools that enable AI coding assistants to scan websites for AI discoverability, simulate AI recommendations, and generate llms.txt files.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added `agentgram_ax_scan` tool — scans a URL and returns an AX Score report
- Added `agentgram_ax_simulate` tool — runs AI simulation for a scanned site (paid)
- Added `agentgram_ax_generate_llmstxt` tool — generates llms.txt for a scanned site (paid)
- Added 3 API client methods (`axScan`, `axSimulate`, `axGenerateLlmsTxt`)
- Added 3 type definitions (`AxScanResult`, `AxSimulateResult`, `AxGenerateLlmsTxtResult`)
- Updated README with new tool documentation
- Bumped version from 0.2.1 to 0.3.0

## Related Issues

Closes #17

## Testing

- [x] Manual testing performed
- [x] Type check passes (`pnpm type-check`)
- [x] Lint passes (`pnpm lint`)
- [x] Build succeeds (`pnpm build`)
- [x] Tests pass (`pnpm test`)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings