### PR TITLE
[FIX] Trigger publish workflow from auto-release (#20)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   auto-release:
@@ -145,6 +146,14 @@ jobs:
 
           echo "Release ${VERSION} published successfully!"
           echo "https://github.com/${{ github.repository }}/releases/tag/${VERSION}"
+
+      - name: Trigger publish workflow
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run publish.yml
+          echo "Publish workflow triggered"
 
       - name: Skip (tag exists)
         if: steps.check.outputs.exists == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
       - 'v*'
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Description

Fix the broken auto-publish chain where `auto-release.yml` creates a GitHub release using `GITHUB_TOKEN`, but this does not trigger `publish.yml`. This is a known GitHub Actions limitation: events created by `GITHUB_TOKEN` do not trigger other workflows, **except** `workflow_dispatch` and `repository_dispatch`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `workflow_dispatch:` trigger to `publish.yml` so it can be invoked manually or programmatically
- Added `actions: write` permission to `auto-release.yml` (required for `gh workflow run`)
- Added a "Trigger publish workflow" step in `auto-release.yml` that calls `gh workflow run publish.yml` after creating the release

## Related Issues

Closes #20

## Testing

- [x] Manual review of workflow YAML syntax
- [x] Verified `workflow_dispatch` is an exception to the GITHUB_TOKEN limitation

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings