### PR TITLE
fix(ci): restore CI for pnpm/action-setup v6

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -30,7 +30,9 @@ jobs:
           LABELS=()
 
           # Parse changed files and assign area labels
-          for file in $CHANGED_FILES; do
+          while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+
             if [[ $file =~ ^src/tools/ ]]; then
               LABELS+=("area: tools")
             elif [[ $file =~ ^src/bin/ ]]; then
@@ -48,7 +50,7 @@ jobs:
             if [[ $file =~ package\.json$ ]] || [[ $file =~ pnpm-lock\.yaml$ ]]; then
               LABELS+=("dependencies")
             fi
-          done
+          done < <(jq -r '.[]' <<< "$CHANGED_FILES")
 
           # Check for breaking changes
           if [[ "$PR_TITLE" =~ BREAKING ]] || [[ "$PR_BODY" =~ BREAKING ]]; then
@@ -56,10 +58,17 @@ jobs:
           fi
 
           # Remove duplicates and format as JSON array
-          UNIQUE_LABELS=($(printf '%s\n' "${LABELS[@]}" | sort -u))
-          LABELS_JSON=$(printf '%s\n' "${UNIQUE_LABELS[@]}" | jq -R . | jq -s .)
+          if [[ ${#LABELS[@]} -eq 0 ]]; then
+            LABELS_JSON='[]'
+          else
+            LABELS_JSON=$(printf '%s\n' "${LABELS[@]}" | sed '/^$/d' | sort -u | jq -R . | jq -sc .)
+          fi
 
-          echo "labels=$LABELS_JSON" >> "$GITHUB_OUTPUT"
+          {
+            echo 'labels<<EOF'
+            echo "$LABELS_JSON"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Apply labels
         if: fromJson(steps.labels.outputs.labels)[0] != null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
+        with:
+          version: 10.4.1
+          run_install: false
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- update CI and publish workflows to use pnpm/action-setup v6
- fix auto-label output handling for JSON changed-files results and labels with spaces
- keep the workflow upgrade from PR #29 but avoid the broken workflow/output path

Refs agentgram-mcp PR #29.